### PR TITLE
Fix unexpected error message of path when using logic.extend()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ const localStoragePlugin = ({ prefix = '', separator = '.', storageEngine = loca
         return
       }
 
-      if (!input.path) {
+      if (!logic.path) {
         console.error('Logic store must have a path specified in order to persist reducer values')
         return
       }


### PR DESCRIPTION
First of all, thank you for the great plugin!

Recently I tried to use `kea-localstorage` and `kea-router` together in a project, and I found I kept getting the error "Logic store must have a path specified in order to persist reducer values" from console even if I have exactly defined the path as well.

I have written a minimal working example which can reproduce this issue: https://github.com/kairyu/kea-localstorage-example

At the end of the day, I found it seems that because `kea-router` uses `logic.extend()` to extend the `router` logic which has no path specified, the extended logic will also be passed into the `buildStep` of `kea-localstorage` as input, and then it causes the error message.

So I thought of a quick fix which just simply change the `input.path` to `logic.path`. But I'm not sure does it really make sense. It would be great if you could get any chance to review this. Thank you in advance.